### PR TITLE
fix stdevs and quantiles options without by

### DIFF
--- a/test.do
+++ b/test.do
@@ -1,0 +1,11 @@
+set trace on 
+set tracedepth 2
+
+sysuse auto
+binscatter2 weight price, quantiles(10 50)
+
+
+binscatter2 weight price, stdevs(1)
+
+binscatter2 weight price, by(foreign) stdevs(1)
+set trace off


### PR DESCRIPTION
Attempted a fix for the stdevs() and quantiles() options when there is no by() group.
These stdevs() still does not work when there is by() (unless that's intended? but I wasn't able to find any documentation regarding this).
Would really appreciate it if you could check it out and fix that, thanks Michael!